### PR TITLE
✨ [Feat] 탈퇴하기, 로그아웃 API 연동

### DIFF
--- a/ReMU/ReMU/Common/Enum/Alert/ActionAlertType.swift
+++ b/ReMU/ReMU/Common/Enum/Alert/ActionAlertType.swift
@@ -17,6 +17,7 @@ enum ActionAlertType {
     case makeGalxy(onConfirm: () -> Void)
     case goBack(onConfirm: () -> Void)
     case error(title: String = "Error", message: String)
+    case withdraw(onConfirm: () -> Void)
     
     var title: String {
         switch self {
@@ -29,6 +30,8 @@ enum ActionAlertType {
         case .makeGalxy : return "아직 은하가 만들어지지 않았네요."
         case .goBack : return "정말 돌아가시겠습니까?"
         case .error(let title, _): return title
+        case .withdraw:
+            return "계정을 삭제하시겠어요?"
         }
         
     }
@@ -36,6 +39,8 @@ enum ActionAlertType {
         switch self {
         case .allowAlarm : return "경고, 사운드 및 아이콘 배치가 알림에 포함될 수 있습니다. 설정에서 이를 구성할 수 있습니다."
         case .makeGalxy : return " 여행을 생성한 뒤에 목표를 설정할 수 있어요!"
+        case .withdraw:
+            return "탈퇴 후 계정 복구는 불가능해요."
         case .error(_, let message): return message
         default : return nil
             
@@ -49,6 +54,7 @@ enum ActionAlertType {
         case .redelete : return "삭제하기"
         case .makeGalxy : return "은하 만들러 가기"
         case .goBack : return "나가기"
+        case .withdraw : return "탈퇴하기"
         default : return "확인"
         }
     }

--- a/ReMU/ReMU/Common/Protocol/Network/TokenProviding.swift
+++ b/ReMU/ReMU/Common/Protocol/Network/TokenProviding.swift
@@ -12,6 +12,8 @@ protocol TokenProviding {
     var refreshToken: String? { get set }
     func refreshToken(completion: @escaping (String?, Error?) -> Void)
     func isTokenExpiringSoon(buffer: TimeInterval) -> Bool
+    func clearSession()
+
 }
 extension TokenProviding {
     func isTokenExpiringSoon() -> Bool {

--- a/ReMU/ReMU/Core/APIProviderStore.swift
+++ b/ReMU/ReMU/Core/APIProviderStore.swift
@@ -22,8 +22,9 @@ extension APIProviderStore {
     }
     /// 로그인 플로우 Provieder
     func auth() -> MoyaProvider<AuthTargetType> {
-        return networkService.createUnauthenticatedProvider(for: AuthTargetType.self)
+        return networkService.createProvider(for: AuthTargetType.self)
     }
+
     
     func galaxy() -> MoyaProvider<GalaxyTargetType> {
         return networkService.createProvider(for: GalaxyTargetType.self)

--- a/ReMU/ReMU/Core/DIContainer/DIContainer.swift
+++ b/ReMU/ReMU/Core/DIContainer/DIContainer.swift
@@ -31,6 +31,10 @@ final class DIContainer: ObservableObject{
     let userSessionKeychain: UserSessionKeychainService
     let apiProviderStore: APIProviderStore
     
+    var tokenProvider: TokenProviding {
+        (networkService as! NetworkServiceImpl).tokenProvider
+    }
+
     init(
         router: NavigationRouter = .init(),
         userSessionKeychain: UserSessionKeychainService = UserSessionKeychainServiceImpl.shared    ) {

--- a/ReMU/ReMU/Models/DTO/Request/User/PatchUserRequest.swift
+++ b/ReMU/ReMU/Models/DTO/Request/User/PatchUserRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PatchUserRequest: Codable {
-    let imageUrl: String?
-    let name : String 
+    let name : String
     let introduction : String?
+    let imageData: Data?
 }

--- a/ReMU/ReMU/Modules/AppFlow/Profile/ViewModel/ProfileViewModel.swift
+++ b/ReMU/ReMU/Modules/AppFlow/Profile/ViewModel/ProfileViewModel.swift
@@ -106,10 +106,10 @@ final class ProfileViewModel: ObservableObject {
     
     // MARK: - 프로필 생성 & 수정
     func updateProfile() async -> Bool {
-            let request = PatchUserRequest(
-                imageUrl: nil,
+        let request = PatchUserRequest(
                 name: username,
-                introduction: description
+                introduction: description.isEmpty ? nil : description,
+                imageData: selectedImageData
             )
 
             do {
@@ -117,6 +117,7 @@ final class ProfileViewModel: ObservableObject {
                 let decoded = try response.map(BaseResponse<UserProfileResponse>.self)
                 return decoded.isSuccess
             } catch {
+                print("프로필 생성/수정 실패", error)
                 return false
             }
         }

--- a/ReMU/ReMU/Modules/Tab/UserMenu/View/MenuView.swift
+++ b/ReMU/ReMU/Modules/Tab/UserMenu/View/MenuView.swift
@@ -14,14 +14,18 @@ struct MenuView: View {
     @State private var isOn = false
     @StateObject private var viewModel: MenuViewModel
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var appState: AppState
+
 
     init(container: DIContainer) {
         _viewModel = StateObject(
             wrappedValue: MenuViewModel(
-                provider: container.apiProviderStore.user()
+                provider: container.apiProviderStore.user(),
+                tokenProvider: container.tokenProvider
             )
         )
     }
+
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -154,14 +158,19 @@ struct MenuView: View {
 
     // MARK: - Bottom Buttons
     private var bottomButtons: some View {
-        VStack(spacing: 24) {
+        VStack(alignment: .center, spacing: 24) {
             Button {
-                AlertManager.shared.show(.delete {})
+                AlertManager.shared.show(.delete {
+                    _Concurrency.Task {
+                        await viewModel.deleteAccount(appState: appState)
+                    }
+                })
             } label: {
                 Text("탈퇴하기")
                     .font(.pt16)
                     .foregroundColor(.false3)
             }
+
 
             Button {
                 AlertManager.shared.show(.logout {})

--- a/ReMU/ReMU/Modules/Tab/UserMenu/View/MenuView.swift
+++ b/ReMU/ReMU/Modules/Tab/UserMenu/View/MenuView.swift
@@ -20,9 +20,11 @@ struct MenuView: View {
     init(container: DIContainer) {
         _viewModel = StateObject(
             wrappedValue: MenuViewModel(
-                provider: container.apiProviderStore.user(),
+                userProvider: container.apiProviderStore.user(),
+                authProvider: container.apiProviderStore.auth(),
                 tokenProvider: container.tokenProvider
             )
+
         )
     }
 
@@ -174,8 +176,11 @@ struct MenuView: View {
 
             Button {
                 AlertManager.shared.show(.logout {
-                    viewModel.logout(appState: appState)
+                    _Concurrency.Task {
+                        await viewModel.logout(appState: appState)
+                    }
                 })
+
             } label: {
                 Text("로그아웃")
                     .font(.pt16)

--- a/ReMU/ReMU/Modules/Tab/UserMenu/View/MenuView.swift
+++ b/ReMU/ReMU/Modules/Tab/UserMenu/View/MenuView.swift
@@ -173,7 +173,9 @@ struct MenuView: View {
 
 
             Button {
-                AlertManager.shared.show(.logout {})
+                AlertManager.shared.show(.logout {
+                    viewModel.logout(appState: appState)
+                })
             } label: {
                 Text("로그아웃")
                     .font(.pt16)

--- a/ReMU/ReMU/Modules/Tab/UserMenu/ViewModel/MenuViewModel.swift
+++ b/ReMU/ReMU/Modules/Tab/UserMenu/ViewModel/MenuViewModel.swift
@@ -17,24 +17,30 @@ final class MenuViewModel: ObservableObject {
     @Published var hasError = false
 
     private let provider: MoyaProvider<UserTargetType>
+    private let tokenProvider: TokenProviding
 
-    init(provider: MoyaProvider<UserTargetType>) {
-            self.provider = provider
-        }
+    init(
+        provider: MoyaProvider<UserTargetType>,
+        tokenProvider: TokenProviding
+    ) {
+        self.provider = provider
+        self.tokenProvider = tokenProvider
+    }
 
+    // MARK: - 프로필 조회 API
     func fetchProfile() async {
         isLoading = true
         hasError = false
-
+        
         do {
             let response = try await provider.requestAsync(.checkUserProfile)
             let decoded = try response.map(BaseResponse<UserProfileResponse>.self)
-
+            
             guard let result = decoded.result else {
                 hasError = true
                 return
             }
-
+            
             profile = UserProfile(
                 name: result.name,
                 introduction: result.introduction,
@@ -43,9 +49,31 @@ final class MenuViewModel: ObservableObject {
         } catch {
             hasError = true
         }
-
+        
         isLoading = false
     }
+    
+    // MARK: - 탈퇴하기 API (계정 삭제)
+    func deleteAccount(appState: AppState) async {
+        do {
+            let response = try await provider.requestAsync(.deleteUser)
+            let decoded = try response.map(BaseResponse<String>.self)
+
+            guard decoded.isSuccess else {
+                AlertManager.shared.showError(message: decoded.message)
+                return
+            }
+
+            AlertManager.shared.show(.confirmDelete {
+                self.tokenProvider.clearSession()
+                appState.route = .auth
+            })
+
+        } catch {
+            AlertManager.shared.showError(message: "탈퇴에 실패했어요.")
+        }
+    }
+
 }
 
 

--- a/ReMU/ReMU/Modules/Tab/UserMenu/ViewModel/MenuViewModel.swift
+++ b/ReMU/ReMU/Modules/Tab/UserMenu/ViewModel/MenuViewModel.swift
@@ -73,6 +73,13 @@ final class MenuViewModel: ObservableObject {
             AlertManager.shared.showError(message: "탈퇴에 실패했어요.")
         }
     }
+    
+    // MARK: - 로그아웃 API
+    func logout(appState: AppState) {
+        tokenProvider.clearSession()
+        appState.route = .auth
+    }
+
 
 }
 

--- a/ReMU/ReMU/Modules/Tab/UserMenu/ViewModel/MenuViewModel.swift
+++ b/ReMU/ReMU/Modules/Tab/UserMenu/ViewModel/MenuViewModel.swift
@@ -16,16 +16,20 @@ final class MenuViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var hasError = false
 
+    private let authProvider: MoyaProvider<AuthTargetType>
     private let provider: MoyaProvider<UserTargetType>
     private let tokenProvider: TokenProviding
 
     init(
-        provider: MoyaProvider<UserTargetType>,
+        userProvider: MoyaProvider<UserTargetType>,
+        authProvider: MoyaProvider<AuthTargetType>,
         tokenProvider: TokenProviding
     ) {
-        self.provider = provider
+        self.provider = userProvider
+        self.authProvider = authProvider
         self.tokenProvider = tokenProvider
     }
+
 
     // MARK: - 프로필 조회 API
     func fetchProfile() async {
@@ -75,10 +79,25 @@ final class MenuViewModel: ObservableObject {
     }
     
     // MARK: - 로그아웃 API
-    func logout(appState: AppState) {
+    func logout(appState: AppState) async {
+        guard let refreshToken = tokenProvider.refreshToken else {
+            tokenProvider.clearSession()
+            appState.route = .auth
+            return
+        }
+
+        do {
+            try await authProvider.requestAsync(
+                .socialLogout(refreshToken: refreshToken)
+            )
+        } catch {
+            print("서버 로그아웃 실패:", error)
+        }
+
         tokenProvider.clearSession()
         appState.route = .auth
     }
+
 
 
 }

--- a/ReMU/ReMU/Resource/Modifier/ActionAlertModifier.swift
+++ b/ReMU/ReMU/Resource/Modifier/ActionAlertModifier.swift
@@ -47,7 +47,7 @@ struct ActionAlertModifier: ViewModifier {
 
     private func getRole(for type: ActionAlertType) -> ButtonRole? {
         switch type {
-        case .delete, .redelete, .logout: return .destructive
+        case .delete, .redelete, .logout, .withdraw: return .destructive
         default: return nil
         }
     }

--- a/ReMU/ReMU/Service/NetworkCore/NetworkServicelmpl.swift
+++ b/ReMU/ReMU/Service/NetworkCore/NetworkServicelmpl.swift
@@ -14,7 +14,7 @@ import Alamofire
 /// - `TokenProviding`을 통해 액세스 토큰을 주입받고, `AccessTokenRefresher`를 이용해 자동 갱신 처리 로직을 포함합니다.
 /// - `Session`과 `MoyaProvider`를 설정하여 API 요청 시 필요한 인증, 로깅, 인터셉터를 적용합니다.
 class NetworkServiceImpl: @unchecked Sendable, NetworkService {
-    private let tokenProvider: TokenProviding
+    let tokenProvider: TokenProviding
     private let accessTokenRefresher: AccessTokenRefresher
     private let session: Session
     private let loggerPlugin: PluginType

--- a/ReMU/ReMU/Service/NetworkCore/TargetType/Auth/AuthTargetType.swift
+++ b/ReMU/ReMU/Service/NetworkCore/TargetType/Auth/AuthTargetType.swift
@@ -41,8 +41,12 @@ extension AuthTargetType: APITargetType {
                 parameters: ["token": token],
                 encoding: JSONEncoding.default
             )
-        case .socialLogout:
-            return .requestPlain
+        case .socialLogout(let refreshToken):
+            return .requestParameters(
+                parameters: ["refreshToken": refreshToken],
+                encoding: JSONEncoding.default
+            )
+
             
         case .tokenRefresh(let refreshToken):
             return .requestParameters(

--- a/ReMU/ReMU/Service/NetworkCore/TargetType/User/UserAPI.swift
+++ b/ReMU/ReMU/Service/NetworkCore/TargetType/User/UserAPI.swift
@@ -16,9 +16,6 @@ enum UserAPI {
     
     // 내 프로필 조회 (로그인 후 사용)
     case getMyProfile
-    
-    // 회원 탈퇴
-    case withdraw
 }
 
 extension UserAPI: TargetType {
@@ -36,15 +33,13 @@ extension UserAPI: TargetType {
             return "/api/v1/auth/login/\(provider)"
         case .getMyProfile:
             return "/user/me"
-        case .withdraw:
-            return "/user/withdraw"
         }
     }
     
     // 요청 행동 - HTTP 메서드
     var method: Moya.Method {
         switch self {
-        case .socialLogin, .withdraw:
+        case .socialLogin:
             return .post // 데이터 전송은 POST
         case .getMyProfile:
             return .get
@@ -61,7 +56,7 @@ extension UserAPI: TargetType {
             ]
             return .requestParameters(parameters: params, encoding: JSONEncoding.default)
             
-        case .getMyProfile, .withdraw:
+        case .getMyProfile:
             // 로그인 된 상태라면 토큰은 Header에 실리므로 body는 비워둠
             return .requestPlain
         }

--- a/ReMU/ReMU/Service/NetworkCore/TargetType/User/UserTargetType.swift
+++ b/ReMU/ReMU/Service/NetworkCore/TargetType/User/UserTargetType.swift
@@ -43,17 +43,53 @@ extension UserTargetType: APITargetType {
     
     var task: Moya.Task {
         switch self {
-        case .patchUser(request: let request):
-            return .requestJSONEncodable(request)
+
+        case .patchUser(let request):
+            var multipartData: [Moya.MultipartFormData] = []
+
+            // name (required)
+            multipartData.append(
+                Moya.MultipartFormData(
+                    provider: .data(request.name.data(using: .utf8)!),
+                    name: "name"
+                )
+            )
+
+            // introduction (optional)
+            if let intro = request.introduction {
+                multipartData.append(
+                    Moya.MultipartFormData(
+                        provider: .data(intro.data(using: .utf8)!),
+                        name: "introduction"
+                    )
+                )
+            }
+
+            // image (optional)
+            if let imageData = request.imageData {
+                multipartData.append(
+                    Moya.MultipartFormData(
+                        provider: .data(imageData),
+                        name: "image",
+                        fileName: "profile.jpg",
+                        mimeType: "image/jpeg"
+                    )
+                )
+            }
+
+            return .uploadMultipart(multipartData)
+
         case .checkUserProfile, .deleteUser:
             return .requestPlain
+
         case let .verifyDuplicateName(name):
-            var params: [String: Any] = ["name": name]
-            return .requestParameters(parameters: params, encoding: URLEncoding.default)
-            
+            return .requestParameters(
+                parameters: ["name": name],
+                encoding: URLEncoding.default
+            )
         }
-        
     }
+
     
     var sampleData: Data {
         return Data("""


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
로그아웃 API 연동
/api/v1/auth/logout 서버 로그아웃 API 연결
refreshToken을 body에 담아 요청하도록 수정
서버 응답 성공 여부와 관계없이 세션 정리 및 .auth 라우팅 처리

탈퇴 API 연동 완료
/api/v1/users/account DELETE 요청 처리
탈퇴 성공 시 세션 제거 후 로그인 화면으로 이동

로컬 로그아웃 -> 서버 로그아웃 방식으로 변경
기존 clearSession()만 처리하던 구조를
서버 로그아웃 API 호출 후 세션 정리하는 구조로 개선

프로필 수정/생성 로직 보완
로그인 -> 프로필 생성 -> 메인 진입 흐름 안정화
로그아웃 후 재로그인 시 isNewUser 값에 따라 정상 분기 처리

## 📋 추후 진행 상황
프로필 수정 API 연결

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)